### PR TITLE
[57] building should work in windows

### DIFF
--- a/src/common/replay.ts
+++ b/src/common/replay.ts
@@ -2,7 +2,7 @@ import * as electron from 'electron'
 import Store         from 'common/store'
 import * as path     from 'path'
 import * as fs       from 'fs'
-import fx            from 'mkdir-recursive'
+import * as fx       from 'mkdir-recursive'
 import * as glob     from 'glob'
 import * as crypto   from 'crypto'
 

--- a/src/common/store.ts
+++ b/src/common/store.ts
@@ -3,7 +3,7 @@ import * as fs         from 'fs'
 import * as path       from 'path'
 import * as DotProp    from 'dot-prop'
 import * as mkdir      from 'make-dir'
-import writeFileAtomic from 'write-file-atomic'
+import * as writeFileAtomic from 'write-file-atomic'
 
 const obj = () => Object.create(null)
 


### PR DESCRIPTION
Windows can't compile due to import syntax errors.
This will fix any issues building in windows.