### PR TITLE
Introduce window.innerWidth and window.innerHeight

### DIFF
--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -24,7 +24,7 @@ function prep_state(klass){
   }
 }
 
-game.state.add('boot'       , prep_state(StatesBoot))
+game.state.add('boot', new StatesBoot());
 game.state.add('load'       , prep_state(StatesLoad))
 game.state.add('menu'       , prep_state(StatesMenu))
 game.state.add('connect'    , prep_state(StatesConnect))

--- a/src/renderer/states/boot.ts
+++ b/src/renderer/states/boot.ts
@@ -1,29 +1,31 @@
-import game from 'core/game'
+import game from 'core/game';
+
+declare var window: {
+  innerWidth: number;
+  innerHeight: number;
+};
+
 export default class StatesBoot {
-  create =()=> {
-    game.stage.backgroundColor = '#282828'
-    this.pixelate()
-    game.state.start('load')
+  create() {
+    game.stage.backgroundColor = '#282828';
+    this.pixelate();
+    game.state.start('load');
   }
 
-  pixelate =()=> {
-    game.stage.disableVisibilityChange = true
+  pixelate() {
+    game.stage.disableVisibilityChange = true;
 
-    game.scale.pageAlignHorizontally = true
-    game.scale.pageAlignVertically = true
+    game.scale.pageAlignHorizontally = true;
+    game.scale.pageAlignVertically = true;
 
-    game.scale.setResizeCallback(this.resize)
+    game.scale.setResizeCallback(this.resize);
 
-    game.renderer.renderSession.roundPixels = true
-    Phaser.Canvas.setImageRenderingCrisp(game.canvas)
+    game.renderer.renderSession.roundPixels = true;
+    Phaser.Canvas.setImageRenderingCrisp(game.canvas);
   }
-  resize =()=> {
-    // need to find a solution in typescript for window
-    // maybe this should be done in electron-main
-    // https://ourcodeworld.com/articles/read/285/how-to-get-the-screen-width-and-height-in-electron-framework
-    let height = 224 * 3// window.innerHeight
-    let width  = 398 * 3// window.innerWidth
-    game.width  = width
-    game.height = height
+
+  resize() {
+    game.width = window.innerWidth;
+    game.height = window.innerHeight;
   }
 }


### PR DESCRIPTION
Global variable `window` isn't currently usable because type
declarations for it are missing. Because of this, size of the game had
to be hardcoded, because it couldn't be read from `window.innerWidth`
and `window.innerHeight`.

As a temporary solution introduce global variable `window` with
`innerWidth` and `innerHeight` properties. As a long term solution, we
are going to need type declarations for the browser API at some point.

And also turn `StatesBoot` into proper class which is introduced as
instance of that class into `game.states` without using the unnecessary
`prep_state` function at all.

Fixes #134