### PR TITLE
[57] bind controls, get rid of remaining fat arrows in components

### DIFF
--- a/src/renderer/components/bauble.ts
+++ b/src/renderer/components/bauble.ts
@@ -30,7 +30,7 @@ export default class ComponentBauble {
   private combo_int0       : Phaser.Sprite
   private combo_small_int0 : Phaser.Sprite
 
-  create =(panel)=> {
+  create(panel) {
     this.panel = panel
     this.create_chain()
     this.create_combo()
@@ -92,7 +92,7 @@ export default class ComponentBauble {
     this.render_combo(x,y)
   }
 
-  render_chain =(x,y)=> {
+  render_chain(x,y) {
     const chain = this.panel.chain
     if (this.panel.state   === CLEAR &&
         this.panel.clear_i === 0     &&
@@ -167,7 +167,7 @@ export default class ComponentBauble {
     }
   }
 
-  render_combo =(x,y)=> {
+  render_combo(x,y) {
     const combo = this.panel.clear_len
     const chain = this.panel.chain
     if (this.panel.state   === CLEAR &&

--- a/src/renderer/components/character.ts
+++ b/src/renderer/components/character.ts
@@ -22,7 +22,7 @@ export default class ComponentCharacter {
    * @param {integer} y default 0
    * @param {integer} pi playfield number
    */
-  create =(sprite, x = 0, y = 0, pi)=> {
+  create(sprite, x = 0, y = 0, pi) {
     this.playfield_num = pi
     // sprite creation
     this.sprite = game.add.sprite(x, y, sprite, 0)
@@ -63,7 +63,7 @@ export default class ComponentCharacter {
    * @param {String} return_to_animation the animation.name to return to after finishing the animation
    * @param {boolean} stop_animation if the animation cycle should in general stop
    */
-  add_animation =(name, hframes, offset, return_to_animation = "", stop_animation = false)=> {
+  add_animation(name, hframes, offset, return_to_animation = "", stop_animation = false) {
     const animation = {
       frames           : [],
       stop_animation   : stop_animation,
@@ -133,7 +133,7 @@ export default class ComponentCharacter {
    * 
    * @param {Array} data information that was sent through this.snap
    */
-  load =(data)=> {
+  load(data) {
     this.tick_counter      = data[0]
     this.frame_counter     = data[1]
     this.stopped           = data[2]

--- a/src/renderer/components/debug_frame.ts
+++ b/src/renderer/components/debug_frame.ts
@@ -6,7 +6,7 @@ export default class ComponentDebugFrame {
     this.lbl = game.add.text(116, 4, '', {font: 'normal 10px Arial',fill: '#FFFFFF'})
   }
 
-  render =(i)=> {
+  render(i) {
     this.lbl.setText(`F${i}`)
   }
 }

--- a/src/renderer/components/menu_cursor.ts
+++ b/src/renderer/components/menu_cursor.ts
@@ -15,7 +15,7 @@ export default class ComponentMenuCursor {
   constructor() {
   }
 
-  create =(menu,x,y,menu_items)=> {
+  create(menu,x,y,menu_items) {
     this.menu = menu;
     this.x = x;
     this.y = y;
@@ -30,17 +30,17 @@ export default class ComponentMenuCursor {
     this.map_controls(1)
   }
 
-  map_controls =(pi)=> {
+  map_controls(pi) {
     return game.controls.map(pi, {
-      up   : this.up,
-      down : this.down,
-      a    : this.confirm,
-      b    : this.cancel,
-      start: this.confirm
+      up   : this.up.bind(this),
+      down : this.down.bind(this),
+      a    : this.confirm.bind(this),
+      b    : this.cancel.bind(this),
+      start: this.confirm.bind(this)
     });
   }
 
-  up =(tick)=> {
+  up(tick) {
     if (tick > 0) { return }
     if (this.index !== 0) {
       game.sounds.select()
@@ -50,7 +50,7 @@ export default class ComponentMenuCursor {
     }
   }
 
-  down =(tick)=> {
+  down(tick) {
     if (tick > 0) { return }
     if (this.index !== (this.menu_items.length-1)) {
       game.sounds.select()
@@ -60,14 +60,14 @@ export default class ComponentMenuCursor {
     }
   }
 
-  confirm =(tick)=> {
+  confirm(tick) {
     if (tick > 0) { return }
     game.sounds.confirm()
     console.log(this.menu_items,this.index)
     return this.menu_items[this.index]()
   }
 
-  cancel =(tick)=> {
+  cancel(tick) {
     if (tick > 0) { return }
     return console.log('cancel');
   }

--- a/src/renderer/components/menu_pause.ts
+++ b/src/renderer/components/menu_pause.ts
@@ -25,7 +25,7 @@ export default class ComponentPauseMenu {
    * create a cursor with no controls provided yet 
    * @param {mode_vs} stage reference to call both playfields 
    */
-  create =(stage)=> {
+  create(stage) {
     this.paused = false;
 
     this.stage = stage;

--- a/src/renderer/components/menu_pause_cursor.ts
+++ b/src/renderer/components/menu_pause_cursor.ts
@@ -27,7 +27,7 @@ export default class ComponentMenuPauseCursor {
    * @param {integer} y pos
    * @param {Array} menu_items functions from menu
    */
-  create =(menu, x, y, menu_items)=> {
+  create(menu, x, y, menu_items) {
     this.menu = menu;
     this.x = x;
     this.y = y;
@@ -44,17 +44,17 @@ export default class ComponentMenuPauseCursor {
    * binds controls to methods of this cursor
    * @param {playerNumber} any_player_number 
    */
-  map_controls =(any_player_number)=> {
+  map_controls(any_player_number) {
     return game.controls.map(any_player_number, {
-      up   : this.up,
-      down : this.down,
-      a    : this.confirm,
-      start: this.confirm
+      up   : this.up.bind(this),
+      down : this.down.bind(this),
+      a    : this.confirm.bind(this),
+      start: this.confirm.bind(this)
     }
     );
   }
 
-  confirm =(tick)=> {
+  confirm(tick) {
     if (tick > 0) 
       return;
 
@@ -62,7 +62,7 @@ export default class ComponentMenuPauseCursor {
     return this.menu_items[this.index]();
   }
 
-  up =(tick)=> {
+  up(tick) {
     if (tick > 0) 
       return;
 
@@ -72,7 +72,7 @@ export default class ComponentMenuPauseCursor {
     }
   }
 
-  down =(tick)=> {
+  down(tick) {
     if (tick > 0) 
       return;
 

--- a/src/renderer/components/panel.ts
+++ b/src/renderer/components/panel.ts
@@ -131,7 +131,7 @@ export default class ComponentPanel {
   }
 
   /** */
-  load =(data)=> {
+  load(data) {
     this.x       = data[0]
     this.y       = data[1]
     this.kind    = data[2]
@@ -146,7 +146,7 @@ export default class ComponentPanel {
   }
 
   /** */
-  create =(playfield, x, y)=> {
+  create(playfield, x, y) {
     /************************************************
     * STATE MACHINE
     ************************************************/
@@ -202,22 +202,22 @@ export default class ComponentPanel {
     });
   }
 
-  swap_l_execute     =(panel)=> { if (panel.counter <= 0) { panel.change_state(SWAPPING_L) } }
-  swap_r_execute     =(panel)=> { if (panel.counter <= 0) { panel.change_state(SWAPPING_R) } }
-  land_execute       =(panel)=> { if (panel.counter <= 0) { panel.change_state(STATIC) } }
-  swapping_l_execute =(panel)=> { if (panel.counter <= 0) { panel.state = STATIC /*TODO: use FSM here*/ } }
-  swapping_r_execute =(panel)=> { if (panel.counter <= 0) { panel.state = STATIC /*TODO: use FSM here*/ } }
-  hang_execute       =(panel)=> { if (panel.counter <= 0) { panel.change_state(FALL) } }
+  swap_l_execute    (panel) { if (panel.counter <= 0) { panel.change_state(SWAPPING_L) } }
+  swap_r_execute    (panel) { if (panel.counter <= 0) { panel.change_state(SWAPPING_R) } }
+  land_execute      (panel) { if (panel.counter <= 0) { panel.change_state(STATIC) } }
+  swapping_l_execute(panel) { if (panel.counter <= 0) { panel.state = STATIC /*TODO: use FSM here*/ } }
+  swapping_r_execute(panel) { if (panel.counter <= 0) { panel.state = STATIC /*TODO: use FSM here*/ } }
+  hang_execute      (panel) { if (panel.counter <= 0) { panel.change_state(FALL) } }
 
-  swapping_r_enter =(panel)=> {
+  swapping_r_enter(panel) {
     panel.counter = TIME_SWAP
   }
 
-  hang_enter =(panel)=> {
+  hang_enter(panel) {
     panel.counter = 0
   }
 
-  swapping_l_enter =(panel)=> {
+  swapping_l_enter(panel) {
     const i1 = panel.kind
     const i2 = panel.right.kind
     panel.kind       = i2
@@ -225,7 +225,7 @@ export default class ComponentPanel {
     panel.counter = TIME_SWAP
   }
 
-  static_execute =(panel)=> {
+  static_execute(panel) {
     if ((panel.under.empty && !panel.empty) || panel.under.state === HANG) {
       panel.change_state(HANG);
     } else if (panel.danger && panel.counter === 0) {
@@ -238,11 +238,11 @@ export default class ComponentPanel {
     }
   }
 
-  land_enter =(panel)=> {
+  land_enter(panel) {
     panel.counter = FRAME_LAND.length
   }
 
-  fall_execute =(panel)=> {
+  fall_execute(panel) {
     if (panel.counter > 0) { return }
       if (panel.under.empty) {
         panel.under.kind    = panel.kind
@@ -268,12 +268,12 @@ export default class ComponentPanel {
         //this.counter = FRAME_LAND.length
   }
 
-  clear_enter =(panel)=> {
+  clear_enter(panel) {
     panel.chain += 1
     panel.playfield.clearing.push(panel)
     panel.group = panel.playfield.stage.tick
   }
-  clear_execute =(panel)=> {
+  clear_execute(panel) {
     if (panel.counter > 0) {
       const [xi,xlen] = panel.clear_index
       panel.clear_i    = xi
@@ -296,7 +296,7 @@ export default class ComponentPanel {
       panel.change_state(STATIC)
     }
   }
-  clear_exit =(panel)=> {
+  clear_exit(panel) {
     panel.kind    = null
     panel.counter = 0
     panel.chain   = 0
@@ -305,7 +305,7 @@ export default class ComponentPanel {
 
 
 
-  set_garbage =(group)=>{
+  set_garbage(group){
     this.state = GARBAGE
     this.panel_garbage.group = group
     this.panel_garbage.state = FALL
@@ -342,7 +342,7 @@ export default class ComponentPanel {
   }
 
   /** */
-  matched =(kind)=>{
+  matched(kind){
     return ((this.left.kind  === kind) && (this.right.kind  === kind)) ||
            ((this.above.kind === kind) && (this.under.kind  === kind)) ||
            ((this.above.kind === kind) && (this.above2.kind === kind)) ||
@@ -364,7 +364,7 @@ export default class ComponentPanel {
     this.sprite.frame = (this.kind * 8) + parseInt(i)
   }
   /** */
-  set_kind =(i)=> {
+  set_kind(i) {
     switch (i) {
       case 'unique':
         this.kind = this.nocombo();
@@ -428,7 +428,7 @@ export default class ComponentPanel {
     Calculates and set the counter for the panel to pop
     @param {{number}} i
   */
-  popping =(i)=> {
+  popping(i) {
     this.counter = TIME_CLEAR + (TIME_POP*i) + TIME_FALL     
   }
 
@@ -522,7 +522,7 @@ export default class ComponentPanel {
   /**
    * exit old state, enter new state, reset state_timer
    */
-  change_state =(state)=> {
+  change_state(state) {
     this.state_timer = 0
     if (this.state_exit.has(this.state))
       this.state_exit.get(this.state)(this)

--- a/src/renderer/components/panel_garbage.ts
+++ b/src/renderer/components/panel_garbage.ts
@@ -35,7 +35,7 @@ export default class ComponentPanelGarbage {
   get group()    {return this._group }
   set group(val) {       this._group = val }
 
-  create =(panel : ComponentPanel ,playfield : ComponentPlayfield)=> {
+  create(panel : ComponentPanel ,playfield : ComponentPlayfield) {
     this.panel     = panel
     this.playfield = playfield
     this.sprite = game.add.sprite(0,0, 'garbage',0)

--- a/src/renderer/components/panel_particle.ts
+++ b/src/renderer/components/panel_particle.ts
@@ -35,7 +35,7 @@ export default class ComponentPanelParticle {
    * @param {object} panel parent which the pos will depend on
    * @param {integer} dir which direction to go - 1 = top left, 2 = top right, 3 = bottom right, ...
    */
-  create =({panel, type = "normal", id, angle = 0})=> {
+  create({panel, type = "normal", id, angle = 0}) {
     this.sprite = game.add.sprite(0, 0, "panel_particles", 0);
     this.sprite.visible = false;
 
@@ -75,7 +75,7 @@ export default class ComponentPanelParticle {
   }
 
   /** loads an Array with integer values that each var should get set to */
-  load =(data)=> {
+  load(data) {
     this.x             = data[0]
     this.y             = data[1]
     this.xdir          = data[2]
@@ -119,7 +119,7 @@ export default class ComponentPanelParticle {
    * @param {integer} current real num from 0 to 1
    * @returns true when current has crossed over ct+1/frames
    */
-  animate_in_intervals =(frames, current)=> {
+  animate_in_intervals(frames, current) {
     return (((this.frame_counter + 1) / frames) <= current)
   }
 

--- a/src/renderer/components/playfield_countdown.ts
+++ b/src/renderer/components/playfield_countdown.ts
@@ -19,7 +19,7 @@ export default class ComponentPlayfieldCountdown {
 
   private states = []
 
-  load =(snapshot)=> {
+  load(snapshot) {
     this.state   = snapshot[0]
     this.counter = snapshot[1]
   }
@@ -28,7 +28,7 @@ export default class ComponentPlayfieldCountdown {
     return [this.state, this.counter]
   }
 
-  create =(playfield)=> {
+  create(playfield) {
     this.playfield = playfield
 
     const x = this.playfield.x+px(16);

--- a/src/renderer/components/playfield_cursor.ts
+++ b/src/renderer/components/playfield_cursor.ts
@@ -33,7 +33,7 @@ export default class ComponentPlayfieldCursor {
    * @param {object} playfield 
    * @param {string} mode B button changes methods depending on the stage
    */
-  create =(playfield, modetype = "vs")=> {
+  create(playfield, modetype = "vs") {
     this.playfield  = playfield
     this.state      = 'hidden'
 
@@ -91,7 +91,7 @@ export default class ComponentPlayfieldCursor {
     ];
   }
 
-  load =(data)=> {
+  load(data) {
     this.x               = data[0];
     this.y               = data[1];
     this.state           = data[2];
@@ -109,15 +109,15 @@ export default class ComponentPlayfieldCursor {
    */
   map_controls() {
     game.controls.map(this.playfield.pi, {
-      up   : this.up,
-      down : this.down,
-      left : this.left,
-      right: this.right,
-      a    : this.swap,
-      b    : this.mode === "vs" ? this.swap : this.undo_swap,
-      l    : this.push,
-      r    : this.push,
-      start: this.pause
+      up   : this.up.bind(this),
+      down : this.down.bind(this),
+      left : this.left.bind(this),
+      right: this.right.bind(this),
+      a    : this.swap.bind(this),
+      b    : this.mode === "vs" ? this.swap.bind(this) : this.undo_swap.bind(this),
+      l    : this.push.bind(this),
+      r    : this.push.bind(this),
+      start: this.pause.bind(this)
     });
   }
 
@@ -126,7 +126,7 @@ export default class ComponentPlayfieldCursor {
    * @param {integer} tick increasing counter
    * @returns bool
    */
-  pressed_then_held =(tick)=> {
+  pressed_then_held(tick) {
     if (tick == 0) 
       this.ignore = false;
 
@@ -142,7 +142,7 @@ export default class ComponentPlayfieldCursor {
    * @param {integer} tick increasing counter
    * @returns true if actually moved
    */
-  up =(tick)=> {
+  up(tick) {
     if (this.pressed_then_held(tick)) 
       if (this.y > ROWS_VIS) {
         this.y--; 
@@ -156,7 +156,7 @@ export default class ComponentPlayfieldCursor {
    * @param {integer} tick increasing counter
    * @returns true if actually moved
    */
-  down =(tick)=> {
+  down(tick) {
     if (this.pressed_then_held(tick))
       if (this.y < (ROWS - 1)) {
         this.y++; 
@@ -170,7 +170,7 @@ export default class ComponentPlayfieldCursor {
    * @param {integer} tick increasing counter
    * @returns true if actually moved
    */
-  left =(tick)=> {
+  left(tick) {
     if (this.pressed_then_held(tick)) 
       if (this.x > 0) { 
           this.x--; 
@@ -184,7 +184,7 @@ export default class ComponentPlayfieldCursor {
    * @param {integer} tick increasing counter
    * @returns true if actually moved
    */
-  right =(tick)=> {
+  right(tick) {
     if (this.pressed_then_held(tick)) 
       if (this.x < (COLS - 2)) { 
         this.x++; 
@@ -201,7 +201,7 @@ export default class ComponentPlayfieldCursor {
    * 
    * @param {integer} tick increasing counter
    */
-  swap =(tick)=> {
+  swap(tick) {
     if (tick > 0 || 
         this.playfield.stage.state !== 'running' || 
         this.state !== 'active') 
@@ -221,7 +221,7 @@ export default class ComponentPlayfieldCursor {
    * undoes the latest swap - up to the beginning before swapping started
    * @param {integer} tick acts as a timer - allows only keypresses
    */
-  undo_swap =(tick)=> {
+  undo_swap(tick) {
     if (tick > 0) 
       return;
 
@@ -234,7 +234,7 @@ export default class ComponentPlayfieldCursor {
    * Calls the Pause method of the stage when a button is pressed
    * @param {integer} tick acts as a timer - allows only keypresses
    */
-  pause =(tick)=> {
+  pause(tick) {
     if (tick > 0) 
       return; 
 
@@ -246,7 +246,7 @@ export default class ComponentPlayfieldCursor {
    * Only triggered when the playfields state is running and the cursor's state is active
    * @param {integer} tick increasing counter
    */
-  push =(tick)=> {
+  push(tick) {
     if (this.playfield.stage.state !== 'running' ||
         this.state !== 'active')
       return;

--- a/src/renderer/components/playfield_wall.ts
+++ b/src/renderer/components/playfield_wall.ts
@@ -17,7 +17,7 @@ export default class ComponentPlayfieldWall {
   private sprite    : Phaser.Sprite
   private counter   : number
 
-  create =(playfield,x,y)=> {
+  create(playfield,x,y) {
     this.playfield = playfield
     this.sprite    = game.add.sprite(x, y, `playfield_wall${this.playfield.pi}`)
     this.counter   = 0

--- a/src/renderer/components/puzzle_menu_cursor.ts
+++ b/src/renderer/components/puzzle_menu_cursor.ts
@@ -11,7 +11,7 @@ export default class PuzzleSelectCursor {
   // need to figure out what this parent is suppose to be
   private parent : any
 
-  create =(parent, x, y)=> {
+  create(parent, x, y) {
     this.x = x;
     this.y = y;
     this.index  = 0;
@@ -24,17 +24,17 @@ export default class PuzzleSelectCursor {
     this.map_controls(1);
   }
 
-  map_controls =(pi)=> {
+  map_controls(pi) {
     return game.controls.map(pi, {
-      up   : this.up,
-      down : this.down,
-      a    : this.confirm,
-      b    : this.cancel,
-      start: this.confirm
+      up   : this.up.bind(this),
+      down : this.down.bind(this),
+      a    : this.confirm.bind(this),
+      b    : this.cancel.bind(this),
+      start: this.confirm.bind(this)
     });
   }
 
-  up =(tick)=> {
+  up(tick) {
     if (tick > 0) 
       return;
 
@@ -42,7 +42,7 @@ export default class PuzzleSelectCursor {
       --this.index;
   }
 
-  down =(tick)=> {
+  down(tick) {
     if (tick > 0) 
       return;
     
@@ -50,11 +50,11 @@ export default class PuzzleSelectCursor {
       ++this.index;
   }
 
-  confirm =(tick)=> {
+  confirm(tick) {
     game.state.start("mode_puzzle", true, false, { chosen_index: this.index });
   }
 
-  cancel =(tick)=> {
+  cancel(tick) {
     if (tick > 0)
       return; 
 

--- a/src/renderer/components/score.ts
+++ b/src/renderer/components/score.ts
@@ -15,7 +15,7 @@ export default class ComponentScore {
     this.lbl.lineSpacing  = -7;
   }
 
-  update =(chain,score)=> {
+  update(chain,score) {
     let text  = `${score}`;
     if (chain) { text += `\nchain: ${chain+1}`; }
     this.lbl.setText(text);

--- a/src/renderer/components/star_counter.ts
+++ b/src/renderer/components/star_counter.ts
@@ -15,7 +15,7 @@ export default class StarCounter {
   private y       : number
   private counter : number
 
-  create =(stage,x,y)=> {
+  create(stage,x,y) {
     this.stage = stage
     this.group = game.add.group()
     this.group.x = x

--- a/src/renderer/components/step_counter.ts
+++ b/src/renderer/components/step_counter.ts
@@ -16,7 +16,7 @@ export default class StepCounter {
    * Add a Sprite group set the parent pos and create sprites on a relative position.
    * @param {object} mulitple vars defaulted - playfield reference is expected.  
    */
-  create =({ step_limit = 0, playfield, x = 200, y = 50})=> {
+  create({ step_limit = 0, playfield, x = 200, y = 50}) {
     this.group = game.add.group();
     this.group.x = x; 
     this.group.y = y;
@@ -56,7 +56,7 @@ export default class StepCounter {
    * @param {integer} n which digit you want to get
    * @returns integer below 10
    */
-  getDigit =(number, n)=> {
+  getDigit(number, n) {
     return Math.floor((number / Math.pow(10, n - 1)) % 10);
   }
 }

--- a/src/renderer/components/timer.ts
+++ b/src/renderer/components/timer.ts
@@ -26,7 +26,7 @@ export default class ComponentTimer {
   /** set all Digit Counters to the snapshots Data
    * @param {Array} snapshot to get data from if packet loss
    */
-  load =(snapshot)=> {
+  load(snapshot) {
     this.d0.frame = snapshot[0];
     this.d0.frame = snapshot[1];
     this.d0.frame = snapshot[2];
@@ -36,7 +36,7 @@ export default class ComponentTimer {
    *  Each Time Digit gets added as a Sprite
    *  Internal tick counter and a bool to stop everything
    */
-  create =(x,y)=> {
+  create(x,y) {
     this.group = game.add.group();
     this.group.x = x;
     this.group.y = y;


### PR DESCRIPTION
Our only scoping issue was coming down to controls and they are now fixed.
All arrows are gone in components
```ts
  map_controls(pi) {
    return game.controls.map(pi, {
      up   : this.up.bind(this),
      down : this.down.bind(this),
      a    : this.confirm.bind(this),
      b    : this.cancel.bind(this),
      start: this.confirm.bind(this)
    });
  }
```