### PR TITLE
store last audio settings

### DIFF
--- a/src/renderer/core/sounds.ts
+++ b/src/renderer/core/sounds.ts
@@ -1,4 +1,7 @@
+import Store from 'common/store'
 import game from 'core/game'
+
+const store = new Store()
 
 /**
  * Sounds class thats attached to the game itself,
@@ -50,6 +53,13 @@ export default class CoreSounds {
 
     this.sfx_blip  = game.add.audio('sfx_countdown_blip')
     this.sfx_ding  = game.add.audio('sfx_countdown_ding')
+  
+    let audio_settings = store.get("audio");
+    if (audio_settings !== undefined) {
+      this.set_sfx_volume(audio_settings[0]);
+      this.set_msx_volume(audio_settings[1]);
+      this.mute_all(audio_settings[2]);
+    }
   } 
 
   /**

--- a/src/renderer/ui/audio.ts
+++ b/src/renderer/ui/audio.ts
@@ -1,10 +1,21 @@
-import game from 'core/game'
-import Ui from 'ui/mode'
-import * as m  from 'mithril'
+import * as m from 'mithril'
 
-let audio_sfx_volume : number = 100
-let audio_msx_volume : number = 100
-let muted : boolean = false
+import game   from 'core/game'
+import Ui     from 'ui/mode'
+import Store  from 'common/store'
+
+const store = new Store()
+let audio_settings = store.get("audio")
+
+let audio_sfx_volume: number = 100
+let audio_msx_volume: number = 100
+let muted: boolean = false
+
+if (audio_settings !== undefined) {
+  audio_sfx_volume = audio_settings[0]
+  audio_msx_volume = audio_settings[1]
+  muted = audio_settings[2]
+}
 
 export default function render() { 
   return m('form',[
@@ -13,6 +24,16 @@ export default function render() {
         min:"0",
         max:"100",
         value: audio_sfx_volume,
+
+        // registered when click is over
+        onclick: function() {
+          store.set("audio", [
+            audio_sfx_volume,
+            audio_msx_volume,
+            muted
+          ])
+        },
+
         oninput: function(e){
           audio_sfx_volume = e.target.value
           game.sounds.set_sfx_volume(audio_sfx_volume * 0.01)
@@ -28,10 +49,20 @@ export default function render() {
         min:"0",
         max:"100",
         value: audio_msx_volume,
+        
+        // registered when click is over
+        onclick: function() {
+          store.set("audio", [
+            audio_sfx_volume,
+            audio_msx_volume,
+            muted
+          ])
+        },
+
         oninput: function(e){
           audio_msx_volume = e.target.value
           game.sounds.set_msx_volume(audio_msx_volume * 0.01)
-        }
+        },
       }),
       m('.val',[
         'Music: ',
@@ -45,10 +76,15 @@ export default function render() {
         onclick: function(e) { 
           muted = !muted;
           game.sounds.mute_all(muted);
+          
+          store.set("audio", [
+            audio_sfx_volume,
+            audio_msx_volume,
+            muted
+          ])
         }
       }),
       m('.val', ['Mute all Audio'])
     ])
   ])
 }
-


### PR DESCRIPTION
On startup the last audio settings are loaded again. The audio settings are saved each time the sliders parameters have been moved and stopped moving or the mute button has been clicked. 

In Sounds the stored settings are applied to the ingame sounds, on startup in UiAudio the settings are loaded as well to position the ui correctly.