### PR TITLE
fix imported in sounds to use full numbers from 0 to 100

### DIFF
--- a/src/renderer/core/sounds.ts
+++ b/src/renderer/core/sounds.ts
@@ -64,9 +64,11 @@ export default class CoreSounds {
 
   /**
    * Sets all current sfx files to the volume amount passed in
-   * @param {integer} decimal_volume from 0.0 to 1.0
+   * @param {integer} volume from 0 to 100
    */
-  set_sfx_volume(decimal_volume) {
+  set_sfx_volume(volume) {
+    let decimal_volume = volume * 0.01
+
     this.sfx_land.forEach(sfx => sfx.volume = decimal_volume)
     this.sfx_pop.forEach(sfx => sfx.volume = decimal_volume)
     this.sfx_confirm.volume = decimal_volume
@@ -77,9 +79,11 @@ export default class CoreSounds {
 
   /**
    * Sets all current msx files to the volume amount passed in
-   * @param {integer} decimal_volume from 0.0 to 1.0
+   * @param {integer} volume from 0 to 100
    */
-  set_msx_volume(decimal_volume) {
+  set_msx_volume(volume) {
+    let decimal_volume = volume * 0.01
+
     this.msx_stage_results.volume  = decimal_volume
     this.msx_stage.volume          = decimal_volume
     this.msx_stage_critical.volume = decimal_volume

--- a/src/renderer/ui/audio.ts
+++ b/src/renderer/ui/audio.ts
@@ -5,12 +5,12 @@ import Ui     from 'ui/mode'
 import Store  from 'common/store'
 
 const store = new Store()
-let audio_settings = store.get("audio")
 
 let audio_sfx_volume: number = 100
 let audio_msx_volume: number = 100
 let muted: boolean = false
 
+let audio_settings = store.get("audio")
 if (audio_settings !== undefined) {
   audio_sfx_volume = audio_settings[0]
   audio_msx_volume = audio_settings[1]
@@ -36,7 +36,7 @@ export default function render() {
 
         oninput: function(e){
           audio_sfx_volume = e.target.value
-          game.sounds.set_sfx_volume(audio_sfx_volume * 0.01)
+          game.sounds.set_sfx_volume(audio_sfx_volume)
         }
       }),
       m('.val',[
@@ -61,7 +61,7 @@ export default function render() {
 
         oninput: function(e){
           audio_msx_volume = e.target.value
-          game.sounds.set_msx_volume(audio_msx_volume * 0.01)
+          game.sounds.set_msx_volume(audio_msx_volume)
         },
       }),
       m('.val',[


### PR DESCRIPTION
small fix to have simply pass full numbers to the sounds methods instead of turning the numbers to decimal values manually. 