### PR TITLE
#219 - swaps are interruptable

### DIFF
--- a/src/renderer/components/panel.ts
+++ b/src/renderer/components/panel.ts
@@ -388,6 +388,7 @@ export default class ComponentPanel {
     if ((this.state === STATIC || this.state === FALL) && this.kind !== null) { return true }
     if (this.state === LAND && this.counter < FRAME_LAND.length) { return true }
     if (this.empty) { return true }
+    if (this.state === SWAP_L || this.state === SWAP_R || this.state === SWAPPING_L || this.state === SWAPPING_R) { return true }
     return false
   }
   /**
@@ -540,9 +541,6 @@ export default class ComponentPanel {
 
     this.counter        = 0
     this.right.counter  = 0
-
-    //this.chain       = 0
-    //this.right.chain = 0
 
     this.change_state(SWAP_L)
     this.right.change_state(SWAP_R)


### PR DESCRIPTION
#219 is basically fully functional, though there are two slight differences from Tetris Attack:

When a swap is interrupted with the same swap, they smoothly maintain their positions (counter) in the swap, and begin reversing. In Swap'N'Pop, they are forced to their swap-finish position, then complete a full swap from there.

eg:
![reswap_unsmooth](https://user-images.githubusercontent.com/15354263/34458458-d176d42e-eda1-11e7-9c02-4bdd4142cd81.gif)

vs

![reswap_smooth](https://user-images.githubusercontent.com/15354263/34458460-e7d37fba-eda1-11e7-9fec-3e389c9a93fb.gif)


Additionally, when only one panel of an old swap is being interrupted, in Tetris Attack it **does** snap to its finished position immediately, whereas in Swap'N'Pop, it continues smoothly towards its destination.

eg:
![swap_interrupt_snp](https://user-images.githubusercontent.com/15354263/34458465-121d46d4-eda2-11e7-815e-a30a02331618.gif)

vs

![swap_interrupt_ta](https://user-images.githubusercontent.com/15354263/34458466-1918b9fa-eda2-11e7-8814-3419470f6eeb.gif)
