### PR TITLE
Chain fixes

### DIFF
--- a/src/renderer/components/panel.ts
+++ b/src/renderer/components/panel.ts
@@ -297,14 +297,14 @@ export default class ComponentPanel {
       let under = this.under
       let ground = false
       while (under !== blank) {
-          if (under.kind !== null && under.state !== SWAP_L && under.state !== SWAPPING_L 
+          if (under.kind !== null && under.state !== LAND && under.state !== SWAP_L && under.state !== SWAPPING_L 
           && under.state !== SWAP_R && under.state !== SWAPPING_R && under.state !== HANG && under.state !== FALL) {
               ground = true
               break
           }         
           under = under.under
       }
-      if (!ground) { this.chain = 0 }
+      if (ground) { this.chain = 0 }
       /*if (under === blank ? true : under.kind !== null && under.state !== SWAP_L && under.state !== SWAPPING_L 
         && under.state !== SWAP_R && under.state !== SWAPPING_R && under.state !== HANG && under.state !== FALL) {
           this.chain = 0

--- a/src/renderer/components/panel.ts
+++ b/src/renderer/components/panel.ts
@@ -278,7 +278,7 @@ export default class ComponentPanel {
 
   land_enter()   { 
     this.counter = FRAME_LAND.length
-    this.chain = this.playfield.chain
+    if (this.chain > 0) { this.chain = this.playfield.chain }
   }
   land_execute() { 
     if (this.counter <= 0) { 
@@ -290,7 +290,7 @@ export default class ComponentPanel {
         this.change_state(STATIC) 
       }
     }
-    else if (this.counter <= FRAME_LAND.length - 2) { 
+    else if (this.counter < FRAME_LAND.length - 1) { 
       // If there is an empty space below in this panel's column, do not reset chain
       let ground = true
       let under = this.under

--- a/src/renderer/components/panel.ts
+++ b/src/renderer/components/panel.ts
@@ -293,12 +293,22 @@ export default class ComponentPanel {
       }
     }
     else if (this.counter < FRAME_LAND.length - 1) { 
-      // Don't reset chain value if below panel is swapping
+      // Don't reset chain value if a panel in column below is swapping, hanging, falling, or empty
       let under = this.under
-      if (under === blank ? true : under.state !== SWAP_L && under.state !== SWAPPING_L 
-      && under.state !== SWAP_R && under.state !== SWAPPING_R && under.state !== HANG && under.state !== FALL) {
-          this.chain = 0
+      let ground = false
+      while (under !== blank) {
+          if (under.kind !== null && under.state !== SWAP_L && under.state !== SWAPPING_L 
+          && under.state !== SWAP_R && under.state !== SWAPPING_R && under.state !== HANG && under.state !== FALL) {
+              ground = true
+              break
+          }         
+          under = under.under
       }
+      if (!ground) { this.chain = 0 }
+      /*if (under === blank ? true : under.kind !== null && under.state !== SWAP_L && under.state !== SWAPPING_L 
+        && under.state !== SWAP_R && under.state !== SWAPPING_R && under.state !== HANG && under.state !== FALL) {
+          this.chain = 0
+      }*/
     } 
   }
 

--- a/src/renderer/components/panel.ts
+++ b/src/renderer/components/panel.ts
@@ -292,6 +292,7 @@ export default class ComponentPanel {
       let ground = true
       let under = this.under
       while (under !== blank) {
+          if (under.state === GARBAGE) { break }
           if (under.kind === null && under.state === STATIC) {
               ground = false
               break
@@ -325,7 +326,7 @@ export default class ComponentPanel {
   }
 
   clear_enter() {
-    this.chain += 1 
+    this.chain += 1
     this.playfield.clearing.push(this)
     this.group = this.playfield.stage.tick
   }

--- a/src/renderer/components/panel.ts
+++ b/src/renderer/components/panel.ts
@@ -278,6 +278,8 @@ export default class ComponentPanel {
 
   land_enter()   { 
     this.counter = FRAME_LAND.length
+    
+    // If chain is 0, it means the panel did not fall as a result of a clear and should not chain
     if (this.chain > 0) { this.chain = this.playfield.chain }
   }
   land_execute() { 
@@ -291,18 +293,12 @@ export default class ComponentPanel {
       }
     }
     else if (this.counter < FRAME_LAND.length - 1) { 
-      // If there is an empty space below in this panel's column, do not reset chain
-      let ground = true
+      // Don't reset chain value if below panel is swapping
       let under = this.under
-      while (under !== blank) {
-          if (under.state === GARBAGE) { break }
-          if (under.kind === null && under.state === STATIC) {
-              ground = false
-              break
-          }
-          under = under.under
+      if (under === blank ? true : under.state !== SWAP_L && under.state !== SWAPPING_L 
+      && under.state !== SWAP_R && under.state !== SWAPPING_R && under.state !== HANG && under.state !== FALL) {
+          this.chain = 0
       }
-      if (ground) { this.chain = 0 }   
     } 
   }
 

--- a/src/renderer/components/panel.ts
+++ b/src/renderer/components/panel.ts
@@ -286,6 +286,19 @@ export default class ComponentPanel {
       else {
         this.change_state(STATIC) 
       }
+    }
+    else if (this.counter <= FRAME_LAND.length - 2) { 
+      // If there is an empty space below in this panel's column, do not reset chain
+      let ground = true
+      let under = this.under
+      while (under !== blank) {
+          if (under.kind === null && under.state === STATIC) {
+              ground = false
+              break
+          }
+          under = under.under
+      }
+      if (ground) { this.chain = 0 }   
     } 
   }
 
@@ -312,7 +325,7 @@ export default class ComponentPanel {
   }
 
   clear_enter() {
-    this.chain += 1
+    this.chain += 1 
     this.playfield.clearing.push(this)
     this.group = this.playfield.stage.tick
   }

--- a/src/renderer/components/panel.ts
+++ b/src/renderer/components/panel.ts
@@ -276,7 +276,10 @@ export default class ComponentPanel {
     }
   }
 
-  land_enter()   { this.counter = FRAME_LAND.length }
+  land_enter()   { 
+    this.counter = FRAME_LAND.length
+    this.chain = this.playfield.chain
+  }
   land_execute() { 
     if (this.counter <= 0) { 
       if (this.under === blank ? false : this.under.state === HANG) {
@@ -326,7 +329,7 @@ export default class ComponentPanel {
   }
 
   clear_enter() {
-    this.chain += 1
+    this.chain++
     this.playfield.clearing.push(this)
     this.group = this.playfield.stage.tick
   }
@@ -348,7 +351,7 @@ export default class ComponentPanel {
       let panel = this.above
       while (panel !== blank && panel.kind !== null && panel.state !== CLEAR) {
           if (panel.static_stable) { 
-            panel.chain += this.chain; 
+            panel.chain = this.chain; 
             panel.change_state(HANG)
           }
           panel = panel.above

--- a/src/renderer/components/panel.ts
+++ b/src/renderer/components/panel.ts
@@ -305,10 +305,6 @@ export default class ComponentPanel {
           under = under.under
       }
       if (ground) { this.chain = 0 }
-      /*if (under === blank ? true : under.kind !== null && under.state !== SWAP_L && under.state !== SWAPPING_L 
-        && under.state !== SWAP_R && under.state !== SWAPPING_R && under.state !== HANG && under.state !== FALL) {
-          this.chain = 0
-      }*/
     } 
   }
 

--- a/src/renderer/components/playfield.ts
+++ b/src/renderer/components/playfield.ts
@@ -315,11 +315,28 @@ export default class Playfield {
     let   chain = 0
     for (let panel of this.clearing){
       panel.popping(this.clearing.length)
-    if (panel.chain > 0) { /*console.log(panel.chain)*/ }
       chain = Math.max(chain,panel.chain)
     }
+    this.chain = Math.max(this.chain,chain)
+    
     for (let panel of this.clearing){ panel.chain = chain }
-    return [combo, chain]
+    
+    // Check if current chain has ended
+    if (this.chain > 0) {
+      let chain_active = false
+      for (i = 0; i < this.stack_size; i++) {
+        if (this.stack_i(i).chain === this.chain) { 
+            chain_active = true
+            break
+        }
+      }
+      if (!chain_active) {
+          // todo: fanfare if >= x4 chain
+          this.chain = 0
+      }
+    }
+    
+    return [combo, this.chain]
   }
 
   /**
@@ -493,7 +510,7 @@ export default class Playfield {
         // combo n chain
         const cnc = this.chain_and_combo()
         this.combo = cnc[0]
-        this.chain = cnc[1]
+        //this.chain = cnc[1]
         if (cnc[1] > 1)
           this.character.current_animation = "charge"
 


### PR DESCRIPTION
#246 - disjointed chains now stack, playfield resets chain counter when highest value chain group has landed without activating a new chain.

Also added a touchup to chain-reset logic on landing, so that drop-in chains work the same as tetris attack. Panels will maintain their chain value if there is an empty space in the column beneath them, since they will end up falling and landing again (or become static somehow, which also resets the chain value)