### PR TITLE
#339 all L shaped combo specs and behaviour fixed

### DIFF
--- a/spec/helper.ts
+++ b/spec/helper.ts
@@ -51,7 +51,7 @@ export function playfield_helper(opts={}){
   stage.state = RUNNING
   const playfield      = new Playfield(0)
   playfield.countdown  = { create: sinon.stub(), update: sinon.stub() }
-  playfield.cursor     = { create: sinon.stub(), update: sinon.stub() }
+  playfield.cursor     = { create: sinon.stub(), reset: sinon.stub(), update: sinon.stub() }
   playfield.menu_pause = { create: sinon.stub(), update: sinon.stub() }
   playfield.score_lbl  = { create: sinon.stub(), update: sinon.stub() }
   playfield.create(stage,{

--- a/spec/integration/update_panel.spec.ts
+++ b/spec/integration/update_panel.spec.ts
@@ -335,12 +335,12 @@ describe('panel_actions', function() {
     chec( [0,20,1,CLEAR,96,1],
           [1,20,1,CLEAR,96,1],
           [2,20,1,CLEAR,96,1],
-          [0,21,1,CLEAR,96,F],
+          [0,21,1,CLEAR,96,1],
           [1,21,2,STATIC,0,F],
-          [2,21,2,STATIC,0,1],
-          [0,22,1,CLEAR,96,F],
+          [2,21,2,STATIC,0,F],
+          [0,22,1,CLEAR,96,1],
           [1,22,2,STATIC,0,F],
-          [2,22,2,STATIC,0,1])
+          [2,22,2,STATIC,0,F])
     update(96)
     chec( [0,20,N,STATIC,0,F],
           [1,20,N,STATIC,0,F],

--- a/spec/integration/update_panel.spec.ts
+++ b/spec/integration/update_panel.spec.ts
@@ -257,8 +257,6 @@ describe('panel_actions', function() {
          [2,22,N,STATIC,0,F])
   })
 
- 
-
   it('#combo_reverese_r5x', function(){
     // 1  1  1
     // 2  2  1
@@ -317,6 +315,42 @@ describe('panel_actions', function() {
          [2,22,N,STATIC,0,F],
          [2,21,N,STATIC,0,F],
          [2,20,N,STATIC,0,F])
+  })
+
+  it('#combo_r5x', function(){
+    // 1  1  1
+    // 1  2  2
+    // 1  2  2
+    load([0,20,1,STATIC,0,F],
+         [1,20,1,STATIC,0,F],
+         [2,20,1,STATIC,0,F],
+         [0,21,1,STATIC,0,F],
+         [1,21,2,STATIC,0,F],
+         [2,21,2,STATIC,0,F],
+         [0,22,1,STATIC,0,F],
+         [1,22,2,STATIC,0,F],
+         [2,22,2,STATIC,0,F])
+    //################################################################
+    update()
+    chec( [0,20,1,CLEAR,96,1],
+          [1,20,1,CLEAR,96,1],
+          [2,20,1,CLEAR,96,1],
+          [0,21,1,STATIC,0,F],
+          [1,21,2,STATIC,0,F],
+          [2,21,2,CLEAR,96,1],
+          [0,22,1,STATIC,0,F],
+          [1,22,2,STATIC,0,F],
+          [2,22,2,CLEAR,96,1])
+    update(96)
+    chec( [0,20,N,STATIC,0,F],
+          [1,20,N,STATIC,0,F],
+          [2,20,N,STATIC,0,F],
+          [0,21,N,STATIC,0,F],
+          [1,21,2,STATIC,0,F],
+          [2,21,2,STATIC,0,F],
+          [0,22,N,STATIC,0,F],
+          [1,22,2,STATIC,0,F],
+          [2,22,2,STATIC,0,F])
   })
 
   it.skip('#chain', function(){

--- a/spec/integration/update_panel.spec.ts
+++ b/spec/integration/update_panel.spec.ts
@@ -335,12 +335,12 @@ describe('panel_actions', function() {
     chec( [0,20,1,CLEAR,96,1],
           [1,20,1,CLEAR,96,1],
           [2,20,1,CLEAR,96,1],
-          [0,21,1,STATIC,0,F],
+          [0,21,1,CLEAR,96,F],
           [1,21,2,STATIC,0,F],
-          [2,21,2,CLEAR,96,1],
-          [0,22,1,STATIC,0,F],
+          [2,21,2,STATIC,0,1],
+          [0,22,1,CLEAR,96,F],
           [1,22,2,STATIC,0,F],
-          [2,22,2,CLEAR,96,1])
+          [2,22,2,STATIC,0,1])
     update(96)
     chec( [0,20,N,STATIC,0,F],
           [1,20,N,STATIC,0,F],

--- a/spec/integration/update_panel.spec.ts
+++ b/spec/integration/update_panel.spec.ts
@@ -230,7 +230,93 @@ describe('panel_actions', function() {
     chec([0,20,N,STATIC,0,F], [1,20,N,STATIC,0,F],
          [0,21,N,STATIC,0,F], [1,21,N,STATIC,0,F],
          [0,22,N,STATIC,0,F], [1,22,N,STATIC,0,F])
-    playfield.score.should.eql(110)
+    //playfield.score.should.eql(110)
+  })
+
+  it('#combo_L5x', function(){
+    // 1
+    // 1
+    // 1  1  1
+    load([0,20,1,STATIC,0,F],
+         [0,21,1,STATIC,0,F],
+         [0,22,1,STATIC,0,F],
+         [1,22,1,STATIC,0,F],
+         [2,22,1,STATIC,0,F])
+    //################################################################
+    update()
+    chec([0,20,1,CLEAR,96,1],
+         [0,21,1,CLEAR,96,1],
+         [0,22,1,CLEAR,96,1],
+         [1,22,1,CLEAR,96,1],
+         [2,22,1,CLEAR,96,1])
+    update(96)
+    chec([0,20,N,STATIC,0,F],
+         [0,21,N,STATIC,0,F],
+         [0,22,N,STATIC,0,F],
+         [1,22,N,STATIC,0,F],
+         [2,22,N,STATIC,0,F])
+  })
+
+ 
+
+  it('#combo_reverese_r5x', function(){
+    // 1  1  1
+    // 2  2  1
+    // 2  2  1
+    load([0,20,1,STATIC,0,F],
+         [1,20,1,STATIC,0,F],
+         [2,20,1,STATIC,0,F],
+         [0,21,2,STATIC,0,F],
+         [1,21,2,STATIC,0,F],
+         [2,21,1,STATIC,0,F],
+         [0,22,2,STATIC,0,F],
+         [1,22,2,STATIC,0,F],
+         [2,22,1,STATIC,0,F])
+    //################################################################
+    update()
+    chec( [0,20,1,CLEAR,96,1],
+          [1,20,1,CLEAR,96,1],
+          [2,20,1,CLEAR,96,1],
+          [0,21,2,STATIC,0,F],
+          [1,21,2,STATIC,0,F],
+          [2,21,1,CLEAR,96,1],
+          [0,22,2,STATIC,0,F],
+          [1,22,2,STATIC,0,F],
+          [2,22,1,CLEAR,96,1])
+    update(96)
+    chec( [0,20,N,STATIC,0,F],
+          [1,20,N,STATIC,0,F],
+          [2,20,N,STATIC,0,F],
+          [0,21,2,STATIC,0,F],
+          [1,21,2,STATIC,0,F],
+          [2,21,N,STATIC,0,F],
+          [0,22,2,STATIC,0,F],
+          [1,22,2,STATIC,0,F],
+          [2,22,N,STATIC,0,F])
+  })
+
+  it('#combo_J5x', function(){
+    //       1
+    //       1
+    // 1  1  1
+    load([0,22,1,STATIC,0,F],
+         [1,22,1,STATIC,0,F],
+         [2,22,1,STATIC,0,F],
+         [2,21,1,STATIC,0,F],
+         [2,20,1,STATIC,0,F])
+    //################################################################
+    update()
+    chec([0,22,1,CLEAR,96,1],
+         [1,22,1,CLEAR,96,1],
+         [2,22,1,CLEAR,96,1],
+         [2,21,1,CLEAR,96,1],
+         [2,20,1,CLEAR,96,1])
+    update(96)
+    chec([0,22,N,STATIC,0,F],
+         [1,22,N,STATIC,0,F],
+         [2,22,N,STATIC,0,F],
+         [2,21,N,STATIC,0,F],
+         [2,20,N,STATIC,0,F])
   })
 
   it.skip('#chain', function(){

--- a/src/renderer/components/panel.ts
+++ b/src/renderer/components/panel.ts
@@ -452,7 +452,7 @@ export default class ComponentPanel {
     if (this.state === STATIC && this.kind !== null) { return true }
     if (this.state === LAND && this.counter < assets.spritesheets.panels.animations.land.length) { return true }
     // 3 already have been marked for being cleared on first frame
-    if (this.state === CLEAR && this.playfield.clearing.indexOf(this) && this.state_timer === 0) { return true }
+    if (this.state === CLEAR && this.playfield.clearing.indexOf(this) !== -1 && this.state_timer === 0) { return true }
     return false
   }
 


### PR DESCRIPTION
I put in new specs for each combo form that resulted in a 5 combo since they didnt exist yet.

The only not working one was r or 
x x x
x 0 0
x 0 0

the issue was simply in the comboable() which was searching looking at if this panel was clearing or not. this resulted in comboable not returning true even tho it was in the clearing array. Array.indexOf(this) returns an index or -1 when this wasnt inside it - and thats what we need to search for. 

if clearing(this) !== -1 it means the panel is inside the currently clearing blocks.